### PR TITLE
Deb package builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info
 .DS_Store
 dist
+package/*.deb

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,0 +1,43 @@
+# Package container with fpm (Linux: alpine) for virtualenv-tools
+# Supported workflow:
+# - Use fpm for python to .deb packaging
+
+# Why alpine?
+# - ruby: => @start ~750MB @end NoData
+# - ruby slim: +> @start ~280MB @end NoData
+# - debian wheezy => @srat ~85MB @end ~280MB
+# - ruby alpine: => @start ~5MB @end ~160MB
+# Why NOT alpine, maybe?
+# - new Linux flavour, new things to learn
+
+FROM ruby:2.3.1-alpine
+
+# Throw errors if Gemfile has been modified since Gemfile.lock.
+RUN bundle config --global frozen 1
+
+COPY Gemfile /
+COPY Gemfile.lock /
+
+### FPM installation ###
+# Package required for:
+# - binutils: provides ar, required by fpm to build deb packages
+# - build-base: only for bundle install, remove later
+# - python: fpm needs python for python input type
+# - py-setuptools: fpm need easy_install for python input type
+# - tar: fpm needs GNU tar (busybox's tar does not support some options)
+RUN apk add --no-cache \
+  bash \
+  binutils \
+  build-base \
+  python \
+  py-setuptools \
+  tar \
+  && bundle install \
+  && apk del build-base
+
+# # Add user without password (-D) and with home (-h)
+RUN adduser -D -h /build builder
+WORKDIR /build
+USER builder
+
+CMD ["/bin/bash"]

--- a/package/Gemfile
+++ b/package/Gemfile
@@ -1,0 +1,6 @@
+# Note:
+# - I won't specify Ruby version here. I use exact pinning in the Dockerfile.
+
+source 'https://rubygems.org' do
+  gem 'fpm', '1.6.3'
+end

--- a/package/Gemfile.lock
+++ b/package/Gemfile.lock
@@ -1,0 +1,48 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    archive-tar-minitar (0.5.2)
+    arr-pm (0.0.10)
+      cabin (> 0)
+    backports (3.6.8)
+    cabin (0.9.0)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
+    clamp (1.0.1)
+    dotenv (2.1.1)
+    ffi (1.9.14)
+    fpm (1.6.3)
+      archive-tar-minitar
+      arr-pm (~> 0.0.10)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      childprocess
+      clamp (~> 1.0.0)
+      ffi
+      json (>= 1.7.7, < 2.0)
+      pleaserun (~> 0.0.24)
+      ruby-xz
+    insist (1.0.0)
+    io-like (0.3.0)
+    json (1.8.3)
+    mustache (0.99.8)
+    pleaserun (0.0.27)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    ruby-xz (0.2.3)
+      ffi (~> 1.9)
+      io-like (~> 0.3)
+    stud (0.0.22)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fpm (= 1.6.3)!
+
+BUNDLED WITH
+   1.13.6

--- a/package/Makefile
+++ b/package/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all
+all:
+	docker build -t virtualenv-tools-fpm .
+	docker run \
+		--env PACKAGE_ITERATION="$(PACKAGE_ITERATION)" \
+		--env PACKAGE_MAINTAINER="$(PACKAGE_MAINTAINER)" \
+		--env APP_VERSION="$(APP_VERSION)" \
+		--tty \
+		--rm \
+		--volume $(PWD)/..:/build \
+	virtualenv-tools-fpm /build/package/package

--- a/package/package
+++ b/package/package
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Package virtualenv-tools into .deb package with fpm.
+#
+# Notes:
+# - This script is designed to run inside a container, so the error handling
+#   is minimal. However, if you have fpm install you can run directly on
+#   your host.
+
+set -euo pipefail
+
+: ${APP_VERSION:?Must be set! (a.k.a. virtualenv_tools application version) See: README}
+: ${PACKAGE_ITERATION:?Must be set! (a.k.a. debian_revision) See: README}
+: ${PACKAGE_MAINTAINER:?Must be set! format: First Last <first.last@prezi.com>}
+
+function main() {
+  fpm \
+    --verbose \
+    --output-type deb \
+    --input-type python \
+    --name python-virtualenv-tools \
+    --maintainer "${PACKAGE_MAINTAINER}" \
+    --prefix /usr/local/ \
+    --description "A set of tools for virtualenv deployment, makes it possible to relocate virtualenvs" \
+    --url "http://github.com/prezi/virtualenv-tools" \
+    --version ${APP_VERSION}-${PACKAGE_ITERATION}prezi \
+    --deb-no-default-config-files \
+    --deb-priority 'optional' \
+    --no-python-dependencies \
+    --python-bin /usr/bin/python2.7 \
+    --python-install-lib lib/python2.7/dist-packages \
+    setup.py
+
+    cd package
+    mv ../*.deb .
+}
+
+main "$@"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-readme = open(os.path.join(os.path.dirname(__file__), 'README'), 'r').read()
+readme = open(os.path.join(os.path.dirname(__file__), 'README.md'), 'r').read()
 
 setup(
     name='virtualenv-tools',


### PR DESCRIPTION
## Reason of the change
Building a deb package is an error-prone manual process, and building on OS X produced a buggy deb package with an OS X absolute path to the python interpreter. We need an easier and more failsafe solution for deb package building.

## Description of the change
I adapted the solution from the ffmpeg package builder in conversion (https://github.com/prezi/conversion/tree/master/package/ffmpeg). This is a docker based fully automatic deb package builder, you just need to set some environment variables and run `make`